### PR TITLE
first step to treating the plugin and VPinMAME as a persistent object

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
+# ScottKirvan/Unreal-Visual-Pinball fork
+
+## Branches
+- Master  - main dev branch - should be good to pull and work with but may have issues
+- dev - development branch - potentially unstable or buggy
+
+## Known Issues
+found a crash:  you can right-click on the pinmame dmd window and stop emulation from there - ue crashes at that point - we may need to check that pController pointer to see if it still has a running game. 
+That pointer is valid for some use when emulation is off, but I'm not sure how we can ensure emulation is active.
+
+## Current project
+Refactoring and reorganizing.  There's some things that are runtime only and there are some 
+features that are editor/dev only in the base VPinMAME API.  I'm working on getting that organized, 
+which means sweeping implementation changes at the moment.  Once that's roughly hashed out, I'll be 
+focusing on stubbing in and fleshing out and hooking the remaining pars of the PinMAME API to Unreal.
+
+Wanna play along?  Help is welcome - you can contact me on my 
+[discord](https://discord.gg/TSKHvVFYxB:w) channel.  I'm cptvideo up there.
+
 # Unreal Pinmame Connection.
-# Connect Unreal Engine to Pinmame pinball emulator
+## Connect Unreal Engine to Pinmame pinball emulator
 I allways have been a fan of pinball machines and I admire the work that has been put into te Pinmame pinball emulator.
 Also a great fan of the Unreal game engine I wanted to connect the Unreal engine to the Pinmame emulator.
 Pinmame is build as a COM control wich makes interfacing not straightforward because you have to deal with things like “Marschalling”.

--- a/Source/UE4_VPinMAME/Private/UE4_VPinMAME.cpp
+++ b/Source/UE4_VPinMAME/Private/UE4_VPinMAME.cpp
@@ -4,9 +4,28 @@
 
 #define LOCTEXT_NAMESPACE "FUE4_VPinMAMEModule"
 
+TSharedRef<FWorkspaceItem> FUE4_VPinMAMEModule::MenuRoot = FWorkspaceItem::NewGroup(FText::FromString("Menu Root"));
+
 void FUE4_VPinMAMEModule::StartupModule()
 {
 	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
+	if (!IsRunningCommandlet())
+	{
+		FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
+		LevelEditorMenuExtensibilityManager = LevelEditorModule.GetMenuExtensibilityManager();
+		MenuExtender = MakeShareable(new FExtender);
+		MenuExtender->AddMenuBarExtension("Window", EExtensionHook::After, NULL, FMenuBarExtensionDelegate::CreateRaw(this, &FUE4_VPinMAMEModule::MakePulldownMenu));
+		LevelEditorMenuExtensibilityManager->AddExtender(MenuExtender);
+	}
+
+		if (!IsRunningCommandlet())
+		{
+			AddModuleListeners();
+			for (int32 i = 0; i < ModuleListeners.Num(); ++i)
+			{
+				ModuleListeners[i]->OnStartupModule();
+			}
+		}
 	
 }
 
@@ -14,9 +33,44 @@ void FUE4_VPinMAMEModule::ShutdownModule()
 {
 	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
 	// we call this function before unloading the module.
+		for (int32 i = 0; i < ModuleListeners.Num(); ++i)
+		{
+			ModuleListeners[i]->OnShutdownModule();
+		}
 	
 }
+
+void FUE4_VPinMAMEModule::AddMenuExtension(const FMenuExtensionDelegate &extensionDelegate, FName extensionHook, const TSharedPtr<FUICommandList> &CommandList, EExtensionHook::Position position)
+{
+	MenuExtender->AddMenuExtension(extensionHook, position, CommandList, extensionDelegate);
+}
+
+void FUE4_VPinMAMEModule::MakePulldownMenu(FMenuBarBuilder &menuBuilder)
+{
+	menuBuilder.AddPullDownMenu(
+		FText::FromString("VPinMAME"),
+		FText::FromString("Open the VPinMAME options menu"),
+		FNewMenuDelegate::CreateRaw(this, &FUE4_VPinMAMEModule::FillPulldownMenu),
+		"Example",
+		FName(TEXT("ExampleMenu"))
+	);
+}
+
+void FUE4_VPinMAMEModule::FillPulldownMenu(FMenuBuilder &menuBuilder)
+{
+	menuBuilder.BeginSection("ExampleSection", FText::FromString("Section 1"));
+	menuBuilder.AddMenuSeparator(FName("Section_1"));
+	menuBuilder.EndSection();
+
+	menuBuilder.BeginSection("ExampleSection", FText::FromString("Section 2"));
+	menuBuilder.AddMenuSeparator(FName("Section_2"));
+	menuBuilder.EndSection();
+}
+
+
 
 #undef LOCTEXT_NAMESPACE
 	
 IMPLEMENT_MODULE(FUE4_VPinMAMEModule, UE4_VPinMAME)
+
+

--- a/Source/UE4_VPinMAME/Private/UE4_VPinMAME.cpp
+++ b/Source/UE4_VPinMAME/Private/UE4_VPinMAME.cpp
@@ -1,10 +1,17 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
 #include "UE4_VPinMAME.h"
+//#include "VPinMAMEMenu/Public/VPinMAMEMenu.h"
+#include "VPinMAMEMenu.h"
 
 #define LOCTEXT_NAMESPACE "FUE4_VPinMAMEModule"
 
 TSharedRef<FWorkspaceItem> FUE4_VPinMAMEModule::MenuRoot = FWorkspaceItem::NewGroup(FText::FromString("Menu Root"));
+
+void FUE4_VPinMAMEModule::AddModuleListeners()
+{
+	ModuleListeners.Add(MakeShareable(new VPinMAMEMenu));
+}
 
 void FUE4_VPinMAMEModule::StartupModule()
 {
@@ -58,12 +65,8 @@ void FUE4_VPinMAMEModule::MakePulldownMenu(FMenuBarBuilder &menuBuilder)
 
 void FUE4_VPinMAMEModule::FillPulldownMenu(FMenuBuilder &menuBuilder)
 {
-	menuBuilder.BeginSection("ExampleSection", FText::FromString("Section 1"));
+	menuBuilder.BeginSection("cExampleSection", FText::FromString("VPinMAME Settings"));
 	menuBuilder.AddMenuSeparator(FName("Section_1"));
-	menuBuilder.EndSection();
-
-	menuBuilder.BeginSection("ExampleSection", FText::FromString("Section 2"));
-	menuBuilder.AddMenuSeparator(FName("Section_2"));
 	menuBuilder.EndSection();
 }
 

--- a/Source/UE4_VPinMAME/Private/UE4_VPinMAME.cpp
+++ b/Source/UE4_VPinMAME/Private/UE4_VPinMAME.cpp
@@ -70,8 +70,6 @@ void FUE4_VPinMAMEModule::FillPulldownMenu(FMenuBuilder &menuBuilder)
 	menuBuilder.EndSection();
 }
 
-
-
 #undef LOCTEXT_NAMESPACE
 	
 IMPLEMENT_MODULE(FUE4_VPinMAMEModule, UE4_VPinMAME)

--- a/Source/UE4_VPinMAME/Private/VPinMAMEMenu.cpp
+++ b/Source/UE4_VPinMAME/Private/VPinMAMEMenu.cpp
@@ -1,0 +1,69 @@
+
+#include "UE4_VPinMAME.h"
+#include "VPinMAMEMenu.h"
+
+#include "ScopedTransaction.h"
+
+#define LOCTEXT_NAMESPACE "VPinMAMEMenu"
+
+class VPinMAMEMenuCommands : public TCommands<VPinMAMEMenuCommands>
+{
+public:
+
+	VPinMAMEMenuCommands()
+		: TCommands<VPinMAMEMenuCommands>(
+		TEXT("VPinMAMEMenu"), // Context name for fast lookup
+		FText::FromString("Example Menu tool"), // Context name for displaying
+		NAME_None,	 // No parent context
+		FEditorStyle::GetStyleSetName() // Icon Style Set
+		)
+	{
+	}
+
+	virtual void RegisterCommands() override
+	{
+		UI_COMMAND(MenuCommand1, "Options...", "Show the VPinMAME Options Dialog.", EUserInterfaceActionType::Button, FInputGesture());
+	}
+
+public:
+	TSharedPtr<FUICommandInfo> MenuCommand1;
+};
+
+void VPinMAMEMenu::MapCommands()
+{
+	const auto& Commands = VPinMAMEMenuCommands::Get();
+
+	CommandList->MapAction(
+		Commands.MenuCommand1,
+		FExecuteAction::CreateSP(this, &VPinMAMEMenu::MenuCommand1),
+		FCanExecuteAction());
+
+}
+
+void VPinMAMEMenu::OnStartupModule()
+{
+	CommandList = MakeShareable(new FUICommandList);
+	VPinMAMEMenuCommands::Register();
+	MapCommands();
+	FUE4_VPinMAMEModule::Get().AddMenuExtension(
+		FMenuExtensionDelegate::CreateRaw(this, &VPinMAMEMenu::MakeMenuEntry),
+		FName("Section_1"),
+		CommandList);
+}
+
+void VPinMAMEMenu::OnShutdownModule()
+{
+	VPinMAMEMenuCommands::Unregister();
+}
+
+void VPinMAMEMenu::MakeMenuEntry(FMenuBuilder &menuBuilder)
+{
+	menuBuilder.AddMenuEntry(VPinMAMEMenuCommands::Get().MenuCommand1);
+}
+
+void VPinMAMEMenu::MenuCommand1()
+{
+	UE_LOG(LogClass, Log, TEXT("clicked MenuCommand1"));
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/UE4_VPinMAME/Private/VPinMAMEMenu.cpp
+++ b/Source/UE4_VPinMAME/Private/VPinMAMEMenu.cpp
@@ -63,12 +63,7 @@ void VPinMAMEMenu::MakeMenuEntry(FMenuBuilder &menuBuilder)
 
 void VPinMAMEMenu::MenuCommand1()
 {
-	UE_LOG(LogClass, Log, TEXT("clicked MenuCommand1"));
-//UVPmame::ShowOptsDialog();
-//UVPmame::ShowAboutDialog();
-	//pController->
-      //virtual HRESULT __stdcall ShowOptsDialog (
-      //virtual HRESULT __stdcall ShowAboutDialog (
+	FUE4_VPinMAMEModule::Get().GetPinMAME()->ShowOptsDialog();
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/UE4_VPinMAME/Private/VPinMAMEMenu.cpp
+++ b/Source/UE4_VPinMAME/Private/VPinMAMEMenu.cpp
@@ -1,6 +1,6 @@
 
-#include "UE4_VPinMAME.h"
 #include "VPinMAMEMenu.h"
+#include "UE4_VPinMAME.h"
 
 #include "ScopedTransaction.h"
 

--- a/Source/UE4_VPinMAME/Private/VPinMAMEMenu.cpp
+++ b/Source/UE4_VPinMAME/Private/VPinMAMEMenu.cpp
@@ -64,6 +64,11 @@ void VPinMAMEMenu::MakeMenuEntry(FMenuBuilder &menuBuilder)
 void VPinMAMEMenu::MenuCommand1()
 {
 	UE_LOG(LogClass, Log, TEXT("clicked MenuCommand1"));
+//UVPmame::ShowOptsDialog();
+//UVPmame::ShowAboutDialog();
+	//pController->
+      //virtual HRESULT __stdcall ShowOptsDialog (
+      //virtual HRESULT __stdcall ShowAboutDialog (
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/UE4_VPinMAME/Private/VPmame.cpp
+++ b/Source/UE4_VPinMAME/Private/VPmame.cpp
@@ -1,6 +1,7 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 
 #include "VPmame.h"
+#include "UE4_VPinMAME.h"
 
 static HICON m_hIcon = 0;
 static IConnectionPointContainer* pControllerConnectionPointContainer = NULL;
@@ -9,11 +10,10 @@ static DWORD dwControllerCookie = 0;
 static HWND hWnd = NULL;
 static BSTR sGameName;
 
-void UVPmame::VPStart(const FString& RomName) // Get romname from blueprint and start Pinmame emulator
-{
-	/* Pinmame COM object creation */
+UVPmame::UVPmame() {
 	CLSID ClsID;
 	HRESULT hr;
+	pController = NULL;
 	hr = CLSIDFromProgID(OLESTR("VPinMAME.Controller"), &ClsID); // Get class ID from program ID
 	if (FAILED(hr)) {
 		UE_LOG(LogTemp, Warning, TEXT("Class couldn't be found. Maybe it isn't registered"));
@@ -43,10 +43,51 @@ void UVPmame::VPStart(const FString& RomName) // Get romname from blueprint and 
 
 	if (SUCCEEDED(hr))
 		hr = pControllerConnectionPointContainer->FindConnectionPoint(__uuidof(_IControllerEvents), &pControllerConnectionPoint);
+
+	FUE4_VPinMAMEModule::Get().SetPinMAME(this);
+};
+
+void UVPmame::VPStart(const FString& RomName) // Get romname from blueprint and start Pinmame emulator
+{
+	/* Pinmame COM object creation */
+	//CLSID ClsID;
+	HRESULT hr;
+	/*
+	hr = CLSIDFromProgID(OLESTR("VPinMAME.Controller"), &ClsID); // Get class ID from program ID
+	if (FAILED(hr)) {
+		UE_LOG(LogTemp, Warning, TEXT("Class couldn't be found. Maybe it isn't registered"));
+		return;
+	}
+	else {
+		UE_LOG(LogTemp, Log, TEXT("Class found."));
+	}
+
+	hr = CoCreateInstance(ClsID, NULL, CLSCTX_INPROC_SERVER, __uuidof(IController), (void**)&pController); // Create COM object
+	if (FAILED(hr)) {
+		UE_LOG(LogTemp, Log, TEXT("Can't create the Controller class! \nPlease check that you have installed Visual PinMAME properly!"));
+		return;
+	}
+	else {
+		UE_LOG(LogTemp, Log, TEXT("Controller class Created."));
+	}
+
+	hr = pController->QueryInterface(IID_IConnectionPointContainer, (void**)&pControllerConnectionPointContainer); // Get pointer to COM interfaces
+	if (FAILED(hr)) {
+		UE_LOG(LogTemp, Log, TEXT("QueryInterface Failed!"));
+		return;
+	}
+	else {
+		UE_LOG(LogTemp, Log, TEXT("QueryInterface succeeded."));
+	}
+
+	if (SUCCEEDED(hr))
+		hr = pControllerConnectionPointContainer->FindConnectionPoint(__uuidof(_IControllerEvents), &pControllerConnectionPoint);
+	*/
  
 
 	/* Emulator settings :Used for testing */
-	pController->put_HandleKeyboard(VARIANT_TRUE); // Allow switch input by keyboard
+	/*
+	hr = pController->put_HandleKeyboard(VARIANT_TRUE); // Allow switch input by keyboard
 	if (FAILED(hr)) {
 		UE_LOG(LogTemp, Log, TEXT("Can't Set HandleKeyboard !"));
 		return;
@@ -65,6 +106,7 @@ void UVPmame::VPStart(const FString& RomName) // Get romname from blueprint and 
 	}
 
 	pController->put_ShowWinDMD(VARIANT_TRUE); // Show UI in resizable window
+	*/
  
 	/* Set romname of emulated pinball machine */
 	char* GameName = TCHAR_TO_ANSI(*RomName);
@@ -92,8 +134,6 @@ void UVPmame::VPStart(const FString& RomName) // Get romname from blueprint and 
 		UE_LOG(LogTemp, Log, TEXT("Running."));
 	}
 	return;
-
-
 }
 
 /* Stop emulator */

--- a/Source/UE4_VPinMAME/Private/VPmame.cpp
+++ b/Source/UE4_VPinMAME/Private/VPmame.cpp
@@ -1,6 +1,5 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 
-
 #include "VPmame.h"
 #include "Windows/AllowWindowsPlatformTypes.h" // Add vanilla C++ header :Start
 
@@ -15,7 +14,6 @@ inline long InterlockedDecrement(long volatile* pn) { return _InterlockedDecreme
 #include "com.h"
 #include "Windows/HideWindowsPlatformTypes.h" // Add vanilla C++ header :End
 
-
 static IController* pController = NULL;
 static HICON m_hIcon = 0;
 static IConnectionPointContainer* pControllerConnectionPointContainer = NULL;
@@ -23,8 +21,6 @@ static IConnectionPoint* pControllerConnectionPoint = NULL;
 static DWORD dwControllerCookie = 0;
 static HWND hWnd = NULL;
 static BSTR sGameName;
-
-
 
 void UVPmame::VPStart(const FString& RomName) // Get romname from blueprint and start Pinmame emulator
 {

--- a/Source/UE4_VPinMAME/Private/VPmame.cpp
+++ b/Source/UE4_VPinMAME/Private/VPmame.cpp
@@ -1,20 +1,7 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 
 #include "VPmame.h"
-#include "Windows/AllowWindowsPlatformTypes.h" // Add vanilla C++ header :Start
 
-extern "C"  // this end-runs a compiler error - but I think it's still functional
-{
-	long __cdecl _InterlockedIncrement(long volatile* pn);
-	long __cdecl _InterlockedDecrement(long volatile* pn);
-}
-inline long InterlockedIncrement(long volatile* pn) { return _InterlockedIncrement(pn); }
-inline long InterlockedDecrement(long volatile* pn) { return _InterlockedDecrement(pn); }
-
-#include "com.h"
-#include "Windows/HideWindowsPlatformTypes.h" // Add vanilla C++ header :End
-
-static IController* pController = NULL;
 static HICON m_hIcon = 0;
 static IConnectionPointContainer* pControllerConnectionPointContainer = NULL;
 static IConnectionPoint* pControllerConnectionPoint = NULL;

--- a/Source/UE4_VPinMAME/Public/UE4_VPinMAME.h
+++ b/Source/UE4_VPinMAME/Public/UE4_VPinMAME.h
@@ -24,8 +24,12 @@ public:
 	virtual void StartupModule();
 	virtual void ShutdownModule();
 
-	virtual void AddModuleListeners() {};
+	virtual void AddModuleListeners();
 
+	static inline FUE4_VPinMAMEModule& Get()
+    {
+        return FModuleManager::LoadModuleChecked< FUE4_VPinMAMEModule >("UE4_VPinMAME");
+    }
 
 
 	void AddMenuExtension(const FMenuExtensionDelegate &extensionDelegate, FName extensionHook, const TSharedPtr<FUICommandList> &CommandList = NULL, EExtensionHook::Position position = EExtensionHook::Before);

--- a/Source/UE4_VPinMAME/Public/UE4_VPinMAME.h
+++ b/Source/UE4_VPinMAME/Public/UE4_VPinMAME.h
@@ -3,12 +3,41 @@
 #pragma once
 
 #include "Modules/ModuleManager.h"
+#include "UnrealEd.h"
+#include "SlateBasics.h"
+#include "SlateExtras.h"
+#include "Editor/LevelEditor/Public/LevelEditor.h"
+#include "Editor/PropertyEditor/Public/PropertyEditing.h"
+#include "IAssetTypeActions.h"
+
+class IVPinMAMEModuleListenerInterface
+{
+public:
+	virtual void OnStartupModule() {};
+	virtual void OnShutdownModule() {};
+};
 
 class FUE4_VPinMAMEModule : public IModuleInterface
 {
 public:
 
-	/** IModuleInterface implementation */
-	virtual void StartupModule() override;
-	virtual void ShutdownModule() override;
-};
+	virtual void StartupModule();
+	virtual void ShutdownModule();
+
+	virtual void AddModuleListeners() {};
+
+
+
+	void AddMenuExtension(const FMenuExtensionDelegate &extensionDelegate, FName extensionHook, const TSharedPtr<FUICommandList> &CommandList = NULL, EExtensionHook::Position position = EExtensionHook::Before);
+
+protected:
+	TArray<TSharedRef<IVPinMAMEModuleListenerInterface>> ModuleListeners;
+	TSharedPtr<FExtender> MenuExtender;
+
+	TSharedPtr<FExtensibilityManager> LevelEditorMenuExtensibilityManager;
+
+	static TSharedRef<FWorkspaceItem> MenuRoot;
+
+	void MakePulldownMenu(FMenuBarBuilder &menuBuilder);
+	void FillPulldownMenu(FMenuBuilder &menuBuilder);
+ };

--- a/Source/UE4_VPinMAME/Public/UE4_VPinMAME.h
+++ b/Source/UE4_VPinMAME/Public/UE4_VPinMAME.h
@@ -9,6 +9,7 @@
 #include "Editor/LevelEditor/Public/LevelEditor.h"
 #include "Editor/PropertyEditor/Public/PropertyEditing.h"
 #include "IAssetTypeActions.h"
+#include "VPmame.h"
 
 class IVPinMAMEModuleListenerInterface
 {
@@ -19,6 +20,7 @@ public:
 
 class FUE4_VPinMAMEModule : public IModuleInterface
 {
+	UVPmame *pPinMame;
 public:
 
 	virtual void StartupModule();
@@ -31,6 +33,8 @@ public:
         return FModuleManager::LoadModuleChecked< FUE4_VPinMAMEModule >("UE4_VPinMAME");
     }
 
+	void SetPinMAME(UVPmame *pMame) { pPinMame = pMame; };
+	UVPmame *GetPinMAME() { return pPinMame; };
 
 	void AddMenuExtension(const FMenuExtensionDelegate &extensionDelegate, FName extensionHook, const TSharedPtr<FUICommandList> &CommandList = NULL, EExtensionHook::Position position = EExtensionHook::Before);
 

--- a/Source/UE4_VPinMAME/Public/VPinMAMEMenu.h
+++ b/Source/UE4_VPinMAME/Public/VPinMAMEMenu.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "UE4_VPinMAME.h"
+
+class VPinMAMEMenu : public IVPinMAMEModuleListenerInterface, public TSharedFromThis<VPinMAMEMenu>
+{
+public:
+	virtual ~VPinMAMEMenu() {}
+
+	virtual void OnStartupModule() override;
+	virtual void OnShutdownModule() override;
+
+	void MakeMenuEntry(FMenuBuilder &menuBuilder);
+
+
+protected:
+	TSharedPtr<FUICommandList> CommandList;
+
+	void MapCommands();
+
+	//************************
+	// UI Command functions
+	void MenuCommand1();
+};

--- a/Source/UE4_VPinMAME/Public/VPmame.h
+++ b/Source/UE4_VPinMAME/Public/VPmame.h
@@ -16,6 +16,7 @@ inline long InterlockedDecrement(long volatile* pn) { return _InterlockedDecreme
 
 #include "com.h"
 #include "Windows/HideWindowsPlatformTypes.h" // Add vanilla C++ header :End
+//#include "UE4_VPinMAME.h"
 #include "VPmame.generated.h"
 
 /**
@@ -30,9 +31,7 @@ class UVPmame : public UBlueprintFunctionLibrary
 	UStaticMeshComponent* StaticMesh;
 	static IController* pController;
 
-	UVPmame() {
-		pController = NULL;
-	};
+	UVPmame();
 
 	/**
 	 * Get romname from blueprint and start PinMAME emulator

--- a/Source/UE4_VPinMAME/Public/VPmame.h
+++ b/Source/UE4_VPinMAME/Public/VPmame.h
@@ -4,6 +4,18 @@
 
 #include "CoreMinimal.h"
 #include "Kismet/BlueprintFunctionLibrary.h"
+#include "Windows/AllowWindowsPlatformTypes.h" // Add vanilla C++ header :Start
+
+extern "C"  // this end-runs a compiler error - but I think it's still functional
+{
+	long __cdecl _InterlockedIncrement(long volatile* pn);
+	long __cdecl _InterlockedDecrement(long volatile* pn);
+}
+inline long InterlockedIncrement(long volatile* pn) { return _InterlockedIncrement(pn); }
+inline long InterlockedDecrement(long volatile* pn) { return _InterlockedDecrement(pn); }
+
+#include "com.h"
+#include "Windows/HideWindowsPlatformTypes.h" // Add vanilla C++ header :End
 #include "VPmame.generated.h"
 
 /**
@@ -16,6 +28,11 @@ class UVPmame : public UBlueprintFunctionLibrary
 	public:
 	UPROPERTY(VisibleAnywhere)
 	UStaticMeshComponent* StaticMesh;
+	static IController* pController;
+
+	UVPmame() {
+		pController = NULL;
+	};
 
 	/**
 	 * Get romname from blueprint and start PinMAME emulator
@@ -195,3 +212,5 @@ class UVPmame : public UBlueprintFunctionLibrary
 #endif
 
 };
+
+IController* UVPmame::pController = NULL;

--- a/Source/UE4_VPinMAME/UE4_VPinMAME.Build.cs
+++ b/Source/UE4_VPinMAME/UE4_VPinMAME.Build.cs
@@ -26,6 +26,7 @@ public class UE4_VPinMAME : ModuleRules
 			new string[]
 			{
 				"Core",
+				"EditorStyle",
 				// ... add other public dependencies that you statically link with here ...
 			}
 			);


### PR DESCRIPTION
Added an editor menu item to pull up the VPinMAME options dialog - this can happen without the rom loaded now.  This involved giving access to the VPinMAME COM object from other system items.  The menu itself may just be a proof of concept for now, as I can envision the rom or a pinball abstraction being seen as an actor (so you can maybe hook the rom into your content folders and have it package-able.  No project file impacts, so the original ij scene and blueprints still work :-)